### PR TITLE
Added note about pagination callbacks to model README

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -256,7 +256,8 @@ response.records.each_with_hit { |record, hit| puts "* #{record.title}: #{hit._s
 
 You can implement pagination with the `from` and `size` search parameters. However, search results
 can be automatically paginated with the [`kaminari`](http://rubygems.org/gems/kaminari) or
-[`will_paginate`](https://github.com/mislav/will_paginate) gems.
+[`will_paginate`](https://github.com/mislav/will_paginate) gems. Note that the respective Gem has 
+to be loaded before Elasticsearch::Model so the callbacks are executed.
 
 If Kaminari or WillPaginate is loaded, use the familiar paging methods:
 


### PR DESCRIPTION
I ran into a bit of an issue where it wasn't entirely clear how pagination was loaded. I had to check out one of the example Rails app which has a caveat:

```
# NOTE: Kaminari has to be loaded before Elasticsearch::Model so the callbacks are executed
```

I copied the note and slightly modified the phrasing so that hopefully nobody in the future to have to take the time to figure out why it isn't working.

Thanks!