### PR TITLE
modified the note about pagination gem order more clearer

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -257,7 +257,7 @@ response.records.each_with_hit { |record, hit| puts "* #{record.title}: #{hit._s
 You can implement pagination with the `from` and `size` search parameters. However, search results
 can be automatically paginated with the [`kaminari`](http://rubygems.org/gems/kaminari) or
 [`will_paginate`](https://github.com/mislav/will_paginate) gems.
-(The pagination gem must be added brfore the elasticsearch gems in your Gemfile, or loaded first in your application.)
+(The pagination gem must be added before the elasticsearch gems in your Gemfile, or loaded first in your application.)
 
 If Kaminari or WillPaginate is loaded, use the familiar paging methods:
 

--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -257,7 +257,7 @@ response.records.each_with_hit { |record, hit| puts "* #{record.title}: #{hit._s
 You can implement pagination with the `from` and `size` search parameters. However, search results
 can be automatically paginated with the [`kaminari`](http://rubygems.org/gems/kaminari) or
 [`will_paginate`](https://github.com/mislav/will_paginate) gems.
-(The gems have to be added _first_ in your Gemfile, or loaded first in your application.)
+(The pagination gem must be added brfore the elasticsearch gems in your Gemfile, or loaded first in your application.)
 
 If Kaminari or WillPaginate is loaded, use the familiar paging methods:
 


### PR DESCRIPTION
the #309  was due to wrong gems order, people can put pagination gem before the elasticsearch gems to avoid it. Put them in the first of Gemfile is not necessary,just keep right order will be fine.