### PR TITLE
elasticsearch-model/README - update index_document with __elasticsearch_...

### DIFF
--- a/elasticsearch-model/README.md
+++ b/elasticsearch-model/README.md
@@ -432,15 +432,15 @@ class Article < ActiveRecord::Base
   include Elasticsearch::Model
 
   after_commit on: [:create] do
-    index_document if self.published?
+    __elasticsearch__.index_document if self.published?
   end
 
   after_commit on: [:update] do
-    update_document if self.published?
+    __elasticsearch__.update_document if self.published?
   end
 
   after_commit on: [:destroy] do
-    delete_document if self.published?
+    __elasticsearch__.delete_document if self.published?
   end
 end
 ```


### PR DESCRIPTION
I was trying to add re-indexing hooks to my program, by following the elasticsearch-model/README, and was getting the error (undefined local variable or method `index_document'). I changed the example to this (see below) and things worked as expected:

````
    after_commit on: [:create, :update] do
      __elasticsearch__.index_document
    end

    after_commit on: [:destroy] do
      __elasticsearch__.delete_document
    end
````

I wondered if the README needed updating? If so, I have added this pull request.