### PR TITLE
Update Regex matching Elasticseach gem so Kaminari will insert correctly

### DIFF
--- a/elasticsearch-rails/lib/rails/templates/02-pretty.rb
+++ b/elasticsearch-rails/lib/rails/templates/02-pretty.rb
@@ -43,7 +43,7 @@ puts        '-'*80, ''; sleep 0.25
 
 # NOTE: Kaminari has to be loaded before Elasticsearch::Model so the callbacks are executed
 #
-insert_into_file 'Gemfile', <<-CODE, before: /gem "elasticsearch".+$/
+insert_into_file 'Gemfile', <<-CODE, before: /gem ["']elasticsearch["'].+$/
 
 # NOTE: Kaminari has to be loaded before Elasticsearch::Model so the callbacks are executed
 gem 'kaminari'


### PR DESCRIPTION
This should fix the issue with the 02-pretty template described in #276. I'm not sure that the main issue described in the issue is related.